### PR TITLE
Add configurable power-up system

### DIFF
--- a/initial plinko game code
+++ b/initial plinko game code
@@ -136,6 +136,21 @@
   // RNG
   let rng = mulberry32(Date.now()>>>0);
 
+  // Power-ups configuration (odds, strength, duration)
+  const powerUpConfig = {
+    magnetPull: {odds:0.02, strength:0.05, duration:3000},
+    multiBall: {odds:0.01},
+    explodingPeg: {odds:0.01},
+    windGust: {odds:0.02, strength:0.6, duration:0},
+    slowMotion: {odds:0.02, strength:0.6, duration:60},
+    bumperPeg: {odds:0.02, strength:1.5, duration:3000}
+  };
+  const inventory = {};
+  function addPowerUp(type,count=1){ inventory[type]=(inventory[type]||0)+count; }
+
+  const audioCtx = new (window.AudioContext||window.webkitAudioContext)();
+  function sound(type){ try{ const osc=audioCtx.createOscillator(), gain=audioCtx.createGain(); osc.connect(gain); gain.connect(audioCtx.destination); const freq=type==='explode'?120:type==='multi'?500:type==='wind'?200:type==='slow'?150:300; osc.frequency.value=freq; gain.gain.value=0.05; osc.start(); osc.stop(audioCtx.currentTime+0.2); }catch(e){} }
+
   // ===== Size & layout =====
   function size(){
     const cssW = window.innerWidth; const cssH = window.innerHeight;
@@ -232,15 +247,47 @@
   }
 
   class Ball{
-    constructor(x,y){ this.x=x; this.y=y; this.r=Math.max(4,pegRadius); this.vx=(rng()-0.5)*0.8; this.vy=INITIAL_VY; this.done=false; this.trail=[]; }
+    constructor(x,y,powerUps=[]){
+      this.x=x; this.y=y; this.r=Math.max(4,pegRadius);
+      this.vx=(rng()-0.5)*0.8; this.vy=INITIAL_VY;
+      this.done=false; this.trail=[];
+      this.powerUps=powerUps;
+      this.hasBumper=powerUps.some(p=>p.type==='bumperPeg');
+      this.split=false;
+    }
     step(){ if(this.done) return;
+      const magnet=this.powerUps.find(p=>p.type==='magnetPull');
+      const wind=this.powerUps.find(p=>p.type==='windGust');
+      const slow=this.powerUps.find(p=>p.type==='slowMotion');
+      const explode=this.powerUps.find(p=>p.type==='explodingPeg');
+      const multi=this.powerUps.find(p=>p.type==='multiBall');
+
+      if(wind && !wind.triggered){
+        wind.triggerY = wind.triggerY || (topOffset + rng()*pegSpacingY*rows);
+        if(this.y > wind.triggerY){ this.vx += (rng()-0.5)*wind.strength; wind.triggered=true; sound('wind'); }
+      }
+      if(explode && !explode.used && this.y > topOffset + pegSpacingY*2){
+        const idx=Math.floor(rng()*pegs.length); if(pegs[idx]) pegs.splice(idx,1);
+        explode.used=true; sound('explode');
+      }
+      if(multi && !this.split && this.y > topOffset + pegSpacingY*rows/2){
+        this.split=true; sound('multi');
+        for(let i=-1;i<=1;i++){ const nb=new Ball(this.x,this.y,this.powerUps.filter(p=>p.type!=='multiBall')); nb.vx=this.vx + i*0.3; nb.vy=this.vy; balls.push(nb); }
+      }
+
       this.vy += GRAVITY; this.vx *= (1-AIR_DRAG); this.vy *= (1-AIR_DRAG*0.5);
+      if(slow && slow.duration>0){ this.vx*=slow.strength; this.vy*=slow.strength; if(--slow.duration===0) sound('slow'); }
+      if(magnet && this.y > H/2){
+        let target=slots[0]; for(const s of slots){ if(s.mult>target.mult) target=s; }
+        const dx=target.x - this.x; this.vx += Math.sign(dx)*magnet.strength;
+      }
+
       this.x += this.vx; this.y += this.vy;
       // collide with trapezoid sides
       collideEdge(this, topLeft,  nLeft);
       collideEdge(this, topRight, nRight);
       // peg collisions
-      for(const p of pegs){ const dx=this.x-p.x, dy=this.y-p.y; const dist=Math.hypot(dx,dy), minD=this.r+p.r; if(dist<minD){ const nx=dx/(dist||1), ny=dy/(dist||1); const overlap=minD-dist+0.004; this.x+=nx*overlap; this.y+=ny*overlap; const vdot=this.vx*nx + this.vy*ny; if(vdot<0){ this.vx -= (1+RESTITUTION)*vdot*nx; this.vy -= (1+RESTITUTION)*vdot*ny; } const tx=-ny, ty=nx; const vtan=this.vx*tx + this.vy*ty; const vnorm=this.vx*nx + this.vy*ny; const vtanD=vtan*TANGENTIAL; this.vx = tx*vtanD + nx*vnorm; this.vy = ty*vtanD + ny*vnorm; this.vx += (rng()-0.5)*JITTER; if(this.vy < MIN_VY_AFTER_HIT) this.vy = MIN_VY_AFTER_HIT; if(Math.abs(this.vx)>MAX_VX) this.vx=Math.sign(this.vx)*MAX_VX; } }
+      for(const p of pegs){ const dx=this.x-p.x, dy=this.y-p.y; const dist=Math.hypot(dx,dy), minD=this.r+p.r; if(dist<minD){ const nx=dx/(dist||1), ny=dy/(dist||1); const overlap=minD-dist+0.004; this.x+=nx*overlap; this.y+=ny*overlap; const vdot=this.vx*nx + this.vy*ny; if(vdot<0){ const bump=this.hasBumper?powerUpConfig.bumperPeg.strength:1; this.vx -= (1+RESTITUTION*bump)*vdot*nx; this.vy -= (1+RESTITUTION*bump)*vdot*ny; } const tx=-ny, ty=nx; const vtan=this.vx*tx + this.vy*ty; const vnorm=this.vx*nx + this.vy*ny; const vtanD=vtan*TANGENTIAL*(this.hasBumper?powerUpConfig.bumperPeg.strength:1); this.vx = tx*vtanD + nx*vnorm; this.vy = ty*vtanD + ny*vnorm; this.vx += (rng()-0.5)*JITTER; if(this.vy < MIN_VY_AFTER_HIT) this.vy = MIN_VY_AFTER_HIT; if(Math.abs(this.vx)>MAX_VX) this.vx=Math.sign(this.vx)*MAX_VX; } }
       const floorY = baseLeft.y + 2; if(this.y>floorY) this.land();
     }
     land(){ this.done=true; let idx=0,md=1e9; for(let i=0;i<slots.length;i++){ const d=Math.abs(this.x - slots[i].x); if(d<md){ md=d; idx=i; } } const mult=slots[idx].mult; const bet=Math.max(0.1, parseFloat(betEl.value||'1')); const win=bet*mult*streak; balance+=win; streak=(mult>=5)?(streak+1):1; renderHUD(); setTimeout(()=>{ const j=balls.indexOf(this); if(j>=0) balls.splice(j,1); }, 120); }
@@ -249,7 +296,18 @@
 
   // ===== UI actions =====
   function renderHUD(){ balanceEl.textContent='$'+balance.toFixed(2); streakEl.textContent='x'+streak; }
-  function drop(){ const bet=Math.max(0.1, parseFloat(betEl.value||'1')); if(balance<bet) return; balance-=bet; renderHUD(); const spread=pegSpacingX*0.30; const centerX=(topLeft.x+topRight.x)/2; const spawnX = centerX + (rng()-0.5)*spread; const spawnY = topLeft.y - SPAWN_HEIGHT; balls.push(new Ball(spawnX,spawnY)); }
+  function drop(){
+    const bet=Math.max(0.1, parseFloat(betEl.value||'1')); if(balance<bet) return;
+    balance-=bet; renderHUD();
+    const spread=pegSpacingX*0.30; const centerX=(topLeft.x+topRight.x)/2;
+    const spawnX = centerX + (rng()-0.5)*spread; const spawnY = topLeft.y - SPAWN_HEIGHT;
+    const powerUps=[];
+    for(const [type,cfg] of Object.entries(powerUpConfig)){
+      if((inventory[type]||0)>0){ powerUps.push({...cfg,type}); inventory[type]--; }
+      else if(rng()< (cfg.odds||0)){ powerUps.push({...cfg,type}); }
+    }
+    balls.push(new Ball(spawnX,spawnY,powerUps));
+  }
 
   manualBtn.addEventListener('click',()=>{ auto=false; manualBtn.classList.add('active'); autoBtn.classList.remove('active'); });
   autoBtn  .addEventListener('click',()=>{ auto=!auto; autoBtn.classList.toggle('active',auto); manualBtn.classList.toggle('active',!auto); });
@@ -284,7 +342,7 @@
   function shade(hex, amt){ const c=parseInt(hex.slice(1),16); let r=(c>>16)&255,g=(c>>8)&255,b=c&255; r=Math.min(255,Math.max(0,r+amt)); g=Math.min(255,Math.max(0,g+amt)); b=Math.min(255,Math.max(0,b+amt)); return '#'+((1<<24)+(r<<16)+(g<<8)+b).toString(16).slice(1); }
   function formatMult(m){ const v=+m; return (v>=10?Math.round(v):v.toFixed(1))+'x'; }
   function drawSlots(){ const y = (slots[0]?.y || (topOffset + (rows-1)*pegSpacingY + 36)) + 6; const h=28; for(let i=0;i<slots.length;i++){ const s=slots[i]; const x=s.x - (s.w-8)/2, w=s.w-8; const col=chipColor(i,slots.length); ctx.save(); ctx.shadowColor='rgba(0,0,0,.4)'; ctx.shadowBlur=10; roundRect(x,y,w,h,9); const gg=ctx.createLinearGradient(0,y,0,y+h); gg.addColorStop(0, shade(col, 14)); gg.addColorStop(1, col); ctx.fillStyle=gg; ctx.fill(); ctx.restore(); ctx.strokeStyle='rgba(0,0,0,.35)'; ctx.stroke(); ctx.save(); ctx.globalAlpha=.25; roundRect(x+2,y+2,w-4,h*.42,7); ctx.fillStyle='#fff'; ctx.fill(); ctx.restore(); const label=formatMult(s.mult); ctx.font='800 12px ui-sans-serif,system-ui,-apple-system,Segoe UI,Roboto,Arial'; ctx.textAlign='center'; ctx.textBaseline='middle'; ctx.fillStyle=(i<2||i>slots.length-3)?'#fff':'#1a1400'; ctx.fillText(label, x+w/2, y+h/2+0.5); } }
-  function drawBall(b){ if(!b.trail) b.trail=[]; b.trail.push({x:b.x,y:b.y}); if(b.trail.length>10) b.trail.shift(); ctx.save(); ctx.globalCompositeOperation='lighter'; for(let i=0;i<b.trail.length;i++){ const t=b.trail[i], a=i/b.trail.length; ctx.globalAlpha=0.08+a*0.14; ctx.beginPath(); ctx.arc(t.x,t.y,b.r*(0.7+a*0.5),0,TAU); ctx.fillStyle='rgba(156,209,255,.55)'; ctx.fill(); } ctx.restore(); ctx.globalAlpha=1; const grad=ctx.createRadialGradient(b.x-2,b.y-3,1.5,b.x,b.y,b.r+7); grad.addColorStop(0,'#ffffff'); grad.addColorStop(.25,'#cfe6ff'); grad.addColorStop(1,'#2b4a7d'); ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,TAU); ctx.fillStyle=grad; ctx.fill(); }
+  function drawBall(b){ if(!b.trail) b.trail=[]; b.trail.push({x:b.x,y:b.y}); if(b.trail.length>10) b.trail.shift(); ctx.save(); ctx.globalCompositeOperation='lighter'; for(let i=0;i<b.trail.length;i++){ const t=b.trail[i], a=i/b.trail.length; ctx.globalAlpha=0.08+a*0.14; ctx.beginPath(); ctx.arc(t.x,t.y,b.r*(0.7+a*0.5),0,TAU); ctx.fillStyle='rgba(156,209,255,.55)'; ctx.fill(); } ctx.restore(); ctx.globalAlpha=1; if(b.powerUps){ let col=null; if(b.powerUps.some(p=>p.type==='magnetPull')) col='rgba(255,80,80,0.6)'; else if(b.powerUps.some(p=>p.type==='windGust')) col='rgba(80,160,255,0.6)'; else if(b.powerUps.some(p=>p.type==='slowMotion')) col='rgba(180,80,255,0.6)'; else if(b.powerUps.some(p=>p.type==='bumperPeg')) col='rgba(255,217,77,0.6)'; if(col){ ctx.save(); ctx.beginPath(); ctx.arc(b.x,b.y,b.r+6,0,TAU); ctx.strokeStyle=col; ctx.lineWidth=2; ctx.stroke(); ctx.restore(); } } const grad=ctx.createRadialGradient(b.x-2,b.y-3,1.5,b.x,b.y,b.r+7); grad.addColorStop(0,'#ffffff'); grad.addColorStop(.25,'#cfe6ff'); grad.addColorStop(1,'#2b4a7d'); ctx.beginPath(); ctx.arc(b.x,b.y,b.r,0,TAU); ctx.fillStyle=grad; ctx.fill(); }
 
   function draw(){ drawBackground(); for(const p of pegs) drawPeg(p); drawSlots(); balls.forEach(b=> b.draw()); }
   function update(){ const now=performance.now(); if(auto && now-lastDrop>dropInterval){ drop(); lastDrop=now; } balls.forEach(b=> b.step()); }


### PR DESCRIPTION
## Summary
- Add configurable power-up system with default odds and audio hooks
- Enhance Ball physics to support Magnet Pull, Multi-Ball, Exploding Peg, Wind Gust, Slow Motion, and Bumper Peg effects
- Extend drawing and drop logic to activate and visualize power-ups

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6896dedd8bd88330885c8e474a231d07